### PR TITLE
Fixed a bug that appears on a Stenomod 15

### DIFF
--- a/stenomod.ino
+++ b/stenomod.ino
@@ -77,6 +77,14 @@ bool look() {
   bool ret = false;
   for(int i = 0; i < 4; i++) {
      uint8_t r = read_column(i);
+     // See if S2 has been pushed,
+     // which sends 11100000 when
+     // it should just be 0000001.
+     if (i == 3 && r & 0x20) {
+      ret = true;
+      r &= ~0x20;
+      b[0] |= 0x01;
+     }
      ret |= r;
      b[i] |= r;
   }


### PR DESCRIPTION
I was recently working on a personal project and wanted to include this code. It didn't initially work on my Stenomod 15 (I'm not sure which revision you're using), so I loaded up a serial analyzer and found that S2 (the upper-left S- key) was sending 0xE0. This, according to Plover's implementation isn't a valid TX Bolt byte, and locks up Plover. It should be the same byte that S1 sends out, 0x01. This change checks to see if that bit is set in b[3] when look() reads it in, and if so, unsets it and sets the appropriate bit in b[0] instead.